### PR TITLE
Sync dot_tmux.conf with live improvements

### DIFF
--- a/.chezmoiexternal.toml
+++ b/.chezmoiexternal.toml
@@ -1,0 +1,4 @@
+[".tmux/plugins/tpm"]
+    type = "git-repo"
+    url = "https://github.com/tmux-plugins/tpm.git"
+    refreshPeriod = "168h"

--- a/README.md
+++ b/README.md
@@ -47,14 +47,11 @@ atuin login -u <USERNAME>
 ## tmux plugin manager (TPM)
 
 The tmux config uses [TPM](https://github.com/tmux-plugins/tpm) to manage
-plugins (`tmux-resurrect`, `tmux-continuum`). TPM itself must be cloned
-manually once:
+plugins (`tmux-resurrect`, `tmux-continuum`). TPM is declared as a chezmoi
+external in `.chezmoiexternal.toml` and will be cloned automatically when you
+run `chezmoi apply` — no manual setup required.
 
-```bash
-git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
-```
-
-Then, inside a running tmux session, install the plugins:
+After applying, install the plugins inside a running tmux session:
 
 ```
 prefix + I   (capital i)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ Then, set up Atuin sync and proceed to the non-mandatory apps below.
 atuin login -u <USERNAME>
 ```
 
+## tmux plugin manager (TPM)
+
+The tmux config uses [TPM](https://github.com/tmux-plugins/tpm) to manage
+plugins (`tmux-resurrect`, `tmux-continuum`). TPM itself must be cloned
+manually once:
+
+```bash
+git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+```
+
+Then, inside a running tmux session, install the plugins:
+
+```
+prefix + I   (capital i)
+```
+
+To update plugins in the future: `prefix + U`.
+
 ## Other applications
 
 The following is not mandatory for dotfiles but is a helpful checklist when

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -1,3 +1,7 @@
+# Extended key support (e.g. Ctrl+Shift combos)
+set -g extended-keys on
+set -as terminal-features 'xterm*:extkeys'
+
 # Enable mouse support (resize panes, scroll, select)
 set -g mouse on
 
@@ -19,7 +23,10 @@ set -g history-limit 100000
 # Reduce delay for ESC / Alt key combos
 set -sg escape-time 10
 
-# Enable truecolor (24-bit color)
+# Use tmux-specific terminfo for accurate capability reporting
+set -g default-terminal "tmux-256color"
+
+# Enable truecolor (24-bit color) on any terminal
 set -ga terminal-overrides ",*:Tc"
 
 # Let tmux pass selections to the outer terminal (OSC 52)
@@ -42,3 +49,18 @@ set-option -g automatic-rename-format '#{b:pane_current_path}'
 
 # Show messages a bit longer
 set -g display-time 2000
+
+# Plugins (managed by TPM)
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+
+# Auto-save and auto-restore sessions
+set -g @continuum-restore 'on'
+
+# Resurrect: restore pane contents and common programs
+set -g @resurrect-capture-pane-contents 'on'
+set -g @resurrect-processes 'pi ssh man less more tail top htop btop watch nvim vim nano'
+
+# Initialize TPM (must be last line)
+run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
Aligns `dot_tmux.conf` with improvements from the live `~/.tmux.conf`, while preserving dotfiles-only settings that hadn't made it back upstream.

## Changes

### Added from live config
- `extended-keys on` + `terminal-features 'xterm*:extkeys'` — modern extended key support (e.g. Ctrl+Shift combos)
- `default-terminal "tmux-256color"` — accurate terminfo for apps like nvim, fzf, less
- TPM plugin manager with `tmux-resurrect` and `tmux-continuum`
- `@continuum-restore on` — auto-restore sessions on startup
- `@resurrect-capture-pane-contents on` + process list

### Kept from dotfiles (not regressed to live)
- `history-limit 100000` (live had 10 000 — kept the larger value)
- `terminal-overrides ",*:Tc"` broad wildcard (live scoped to `*256col*` — kept broader for full truecolor support)